### PR TITLE
change the stable properties

### DIFF
--- a/book/content/part04/quick-sort.asc
+++ b/book/content/part04/quick-sort.asc
@@ -77,7 +77,7 @@ With the optimization, Quicksort has an _O(n log n)_ running time. Similar to th
 
 ===== Quicksort Properties
 
-- <<Stable>>: [big]#✅# Yes
+- <<Stable>>: [big]#❌# No
 - <<In-place>>: [big]#✅# Yes
 - <<Adaptive>>: [big]#️❌# No, mostly sorted array takes the same time O(n log n).
 - <<Online>>: [big]#️❌# No, the pivot element can be choose at random.


### PR DESCRIPTION
Quick Sort is always unstable because of the relative order of records in the case of an equality of keys. 