### PR TITLE
fix(graph): minor typo in bfs code documentation

### DIFF
--- a/src/data-structures/graphs/graph.js
+++ b/src/data-structures/graphs/graph.js
@@ -134,7 +134,7 @@ class Graph {
   }
 
   /**
-   * Depth-first search
+   * Breadth-first search
    * Use a queue to visit nodes (FIFO)
    * @param {Node} first node to start the dfs
    */


### PR DESCRIPTION
"bfs*" inline documentation should read "Breadth-first search"

Fixes #110